### PR TITLE
More APIs and performance improvements

### DIFF
--- a/benchmarks/bench_traversal.py
+++ b/benchmarks/bench_traversal.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 import math
+import time
 import timeit
 from dataclasses import dataclass, field
 
@@ -46,16 +45,18 @@ def run_benchmark():
     TREE_MAX_SIZE = 1000000
     DEPTH = 18
     max_nodes = math.floor(math.pow(TREE_MAX_SIZE, 1 / DEPTH))
+
+    st = time.monotonic()
     tree = gen_sample_tree(DEPTH, max_nodes)
 
-    print(f"Tree size: {COUNTER}")
+    print(f"Time to build tree with {COUNTER} nodes: {time.monotonic() - st:.6f} seconds")
 
     n = 10
-    time = timeit.timeit(lambda: list(tree.dfs()), number=n)
-    print(f"Stack based DFS (tree size: {COUNTER}, invocations: {n}): {time:.6f} seconds")
+    ttime = timeit.timeit(lambda: list(tree.dfs()), number=n)
+    print(f"Stack based DFS (tree size: {COUNTER}, invocations: {n}): {ttime:.6f} seconds")
 
-    time = timeit.timeit(lambda: list(tree.bfs()), number=n)
-    print(f"Queue based BFS (tree size: {COUNTER}, invocations: {n}): {time:.6f} seconds")
+    ttime = timeit.timeit(lambda: list(tree.bfs()), number=n)
+    print(f"Queue based BFS (tree size: {COUNTER}, invocations: {n}): {ttime:.6f} seconds")
 
 
 if __name__ == "__main__":

--- a/src/pyoak/node.py
+++ b/src/pyoak/node.py
@@ -348,7 +348,15 @@ class ASTNode(DataClassSerializeMixin):
         """
         return NODE_REGISTRY.get(id, default)
 
-    def detach(self) -> bool:
+    def detach(self) -> None:
+        """Removes this node and and the whole tree rooted with this node from
+        the registry."""
+        NODE_REGISTRY.pop(self.id, None)
+
+        for ni in self.dfs():
+            NODE_REGISTRY.pop(ni.node.id, None)
+
+    def detach_self(self) -> bool:
         """Removes this node from the registry.
 
         Returns:

--- a/src/pyoak/node.py
+++ b/src/pyoak/node.py
@@ -7,7 +7,7 @@ import sys
 import weakref
 from collections import deque
 from collections.abc import Generator, Iterable
-from dataclasses import InitVar, dataclass, field, replace
+from dataclasses import dataclass, field, replace
 from inspect import getmro
 from typing import TYPE_CHECKING, Any, Callable, Deque, Mapping, NamedTuple, Sequence, TypeVar, cast
 
@@ -76,9 +76,12 @@ def _eq_fn(self: ASTNode, other: ASTNode) -> bool:
     return False
 
 
-# Hack to make dataclasses InitVar work with future annotations
-# See https://stackoverflow.com/questions/70400639/how-do-i-get-python-dataclass-initvar-fields-to-work-with-typing-get-type-hints
-InitVar.__call__ = lambda *args: None  # type: ignore
+if sys.version_info < (3, 11):
+    from dataclasses import InitVar
+
+    # Hack to make dataclasses InitVar work with future annotations
+    # See https://stackoverflow.com/questions/70400639/how-do-i-get-python-dataclass-initvar-fields-to-work-with-typing-get-type-hints
+    InitVar.__call__ = lambda *args: None  # type: ignore
 
 
 def _check_runtime_types(node: ASTNode, type_map: Mapping[Field, FieldTypeInfo]) -> Sequence[Field]:

--- a/src/pyoak/node.py
+++ b/src/pyoak/node.py
@@ -64,7 +64,14 @@ def _hash_fn(node: ASTNode) -> int:
 def _eq_fn(self: ASTNode, other: ASTNode) -> bool:
     # Other typed as ASTNode to make mypy happy
     if other.__class__ is self.__class__:
-        return self.content_id == other.content_id and self.origin == other.origin
+        if self.content_id == other.content_id and self.origin == other.origin:
+            # If content matches and origin matches, we only need to check
+            # children origins. Content is guaranteed to be the same
+            for si, oi in zip(self.dfs(), other.dfs(), strict=True):
+                if si.node.origin != oi.node.origin:
+                    return False
+
+            return True
 
     return False
 

--- a/src/pyoak/types.py
+++ b/src/pyoak/types.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Mapping
+
+from pyoak.typing import process_node_fields
+
+if TYPE_CHECKING:
+    from dataclasses import Field as DataClassField
+
+    from .node import ASTNode
+    from .typing import FieldTypeInfo
+
+    Field = DataClassField[Any]
+
+# Cached mappings of ASTNode subclasses to their properties and child fields
+_TYPE_TO_ALL_FIELDS: dict[type[ASTNode], Mapping[Field, FieldTypeInfo]] = {}
+_TYPE_TO_CHILD_FIELDS: dict[type[ASTNode], Mapping[Field, FieldTypeInfo]] = {}
+_TYPE_TO_PROPS: dict[type[ASTNode], Mapping[Field, FieldTypeInfo]] = {}
+
+
+def _populate_type_dicts(cls: type[ASTNode]) -> None:
+    """Returns a tuple of all fields of the given class."""
+
+    # Dynamic import to avoid circular imports
+    from .node import ASTNode
+
+    _TYPE_TO_CHILD_FIELDS[cls], _TYPE_TO_PROPS[cls] = process_node_fields(cls, ASTNode)
+
+    _TYPE_TO_ALL_FIELDS[cls] = {
+        **_TYPE_TO_CHILD_FIELDS[cls],
+        **_TYPE_TO_PROPS[cls],
+    }
+
+
+def get_cls_all_fields(cls: type[ASTNode]) -> Mapping[Field, FieldTypeInfo]:
+    """Returns a tuple of all fields of the given class."""
+    if cls not in _TYPE_TO_ALL_FIELDS:
+        _populate_type_dicts(cls)
+
+    return _TYPE_TO_ALL_FIELDS[cls]
+
+
+def get_cls_child_fields(cls: type[ASTNode]) -> Mapping[Field, FieldTypeInfo]:
+    """Returns a tuple of all child fields of the given class.
+
+    Raises:
+        InvalidFieldTypes: If the class has fields with mixed ASTNode subclasses and regular types or
+            unsupported child fileds types (e.g. mutable collections of ASTNode's).
+    """
+    if cls not in _TYPE_TO_CHILD_FIELDS:
+        _populate_type_dicts(cls)
+
+    return _TYPE_TO_CHILD_FIELDS[cls]
+
+
+def get_cls_props(cls: type[ASTNode]) -> Mapping[Field, FieldTypeInfo]:
+    """Returns a tuple of all properties of the given class.
+
+    Raises:
+        InvalidFieldTypes: If the class has fields with mixed ASTNode subclasses and regular types or
+            unsupported child fileds types (e.g. mutable collections of ASTNode's).
+    """
+    if cls not in _TYPE_TO_PROPS:
+        _populate_type_dicts(cls)
+
+    return _TYPE_TO_PROPS[cls]

--- a/src/pyoak/visitor.py
+++ b/src/pyoak/visitor.py
@@ -105,7 +105,7 @@ class ASTTransformVisitor(ASTVisitor[ASTNode | None]):
                     # Removed child, mark as changed field
                     field_names_with_changes.add(fname)
             else:
-                new_child = self.transform(child)
+                new_child = self.visit(child)
 
                 changes[fname] = new_child
 
@@ -142,6 +142,5 @@ class ASTTransformVisitor(ASTVisitor[ASTNode | None]):
         # Return a new node with the changes
         return replace(node, **changes)
 
-    def transform(self, node: ASTNode) -> ASTNode | None:
-        """Am alias for visit method."""
-        return self.visit(node)
+    transform = ASTVisitor[ASTNode | None].visit
+    """Am alias for visit method."""

--- a/tests/pyoak/test_node.py
+++ b/tests/pyoak/test_node.py
@@ -151,11 +151,14 @@ def test_id_handling(pyoak_config: ConfigFixtureProtocol) -> None:
         # different content that will collide
         other_node = ChildNode("L3C2089KVA")
 
-        # for same value the collision resolution is via a counter
-        assert new_node.id == f"{node.id}_1"
+        assert len({node.id, new_node.id, other_node.id}) == 3
 
-        # for different values the collision resolution is via a longer digest
-        assert len(other_node.id) == 4
+        for n in (node, new_node, other_node):
+            assert n is ASTNode.get_any(n.id)
+
+        # the collision resolution is via a counter
+        assert new_node.id == f"{node.id}_1"
+        assert other_node.id == f"{node.id}_2"
 
 
 def test_runtime_type_checks(pyoak_config: ConfigFixtureProtocol) -> None:

--- a/tests/pyoak/test_node.py
+++ b/tests/pyoak/test_node.py
@@ -514,25 +514,36 @@ def test_children() -> None:
     assert list(parent.children) == ch_nodes
 
 
-def test_is_equal() -> None:
+def test_equality() -> None:
+    # Testing the full equality (==) and content-wise equality (is_equal)
+
+    # Test euqal itself
     one = ChildNode("1", origin=origin)
     assert one.is_equal(one)
+    assert one == one
 
+    # Test different types & values
     two = ChildNode("2", origin=origin)
     other_type_ast = OtherNode("1", origin=origin)
     assert not one.is_equal("Test not ASTNode")
     assert not one.is_equal(other_type_ast)
     assert not one.is_equal(two)
+    assert one != "Test not ASTNode"
+    assert one != other_type_ast
+    assert one != two
 
+    # Test different origins
     other_origin = CodeOrigin(MemoryTextSource("test2"), get_code_range(0, 1, 0, 4, 1, 4))
     other_origin_one = ChildNode("1", origin=other_origin)
     assert one != other_origin_one
     assert one.is_equal(other_origin_one)
 
+    # Same content and origin
     collided_one = ChildNode("1", origin=origin)
     assert one == collided_one
     assert one.is_equal(collided_one)
 
+    # Test with duplicate
     duplicated_one = one.duplicate()
     assert one == duplicated_one
     assert one.is_equal(duplicated_one)
@@ -552,34 +563,35 @@ def test_is_equal() -> None:
 
     other_parent = ParentNode(
         attr="Parent",
-        single_child=ChildNode("single_child", origin=other_origin),
+        single_child=ChildNode("single_child", origin=origin),
         child_seq=(
-            ChildNode("child_list1", origin=other_origin),
-            ChildNode("child_list2", origin=other_origin),
+            ChildNode("child_list1", origin=origin),
+            ChildNode("child_list2", origin=other_origin),  # changed origin
         ),
         not_a_child_seq=(),
-        origin=other_origin,
+        origin=origin,
     )
     assert parent != other_parent
     assert parent.is_equal(other_parent)
 
     other_parent = ParentNode(
         attr="Parent",
-        single_child=ChildNode("single_child", origin=other_origin),
+        single_child=ChildNode("single_child", origin=origin),
         child_seq=(
-            ChildNode("child_list1", origin=other_origin),
-            ChildNode("child_list2-changed", origin=other_origin),
+            ChildNode("child_list1", origin=origin),
+            ChildNode("child_list2-changed", origin=origin),
         ),
         not_a_child_seq=(),
-        origin=other_origin,
+        origin=origin,
     )
     assert parent != other_parent
     assert not parent.is_equal(other_parent)
 
-    # Check hidden attrs (should not be compared)
+    # Check non-compare attrs (should not be compared)
     hidone = NonCompareAttrNode(attr="1", non_compare_attr="one", origin=origin)
     hidtwo = NonCompareAttrNode(attr="1", non_compare_attr="two", origin=origin)
     assert hidone.is_equal(hidtwo)
+    assert hidone == hidtwo
 
 
 def test_to_properties_dict() -> None:


### PR DESCRIPTION
New stuff:
* ✨ detach and detach_self API
* ✨ sort_keys option for child and prop API's

Clean-up:
* 🔥 only apply InitVar hack on py3.10
* 🎨 move all codegen code into codegen module
* 🎨 move field type getters to types module

Optimisations:
* ✨ faster node creation using new statically sorted field getters
* 🔥 dump different id collision approaches
* ✨ alias transform method to avoid extra frame

Bugs:
* 🐛 make sure equality honors nested origins

Other:
* ✨ add tree build time to traversal bench
make it suitable for cProfile






